### PR TITLE
Do not check for duplicates

### DIFF
--- a/Sources/KeyStore.Error.swift
+++ b/Sources/KeyStore.Error.swift
@@ -8,15 +8,12 @@ import Foundation
 
 extension KeyStore {
     public enum Error: Swift.Error, LocalizedError {
-        case accountAlreadyExists
         case accountNotFound
         case invalidMnemonic
         case invalidKey
 
         public var errorDescription: String? {
             switch self {
-            case .accountAlreadyExists:
-                return NSLocalizedString("Account already exists", comment: "Error message when trying to add an account that already exists")
             case .accountNotFound:
                 return NSLocalizedString("Account not found", comment: "Error message when trying to access an account that does not exist")
             case .invalidMnemonic:

--- a/Sources/KeyStore.swift
+++ b/Sources/KeyStore.swift
@@ -80,9 +80,6 @@ public final class KeyStore {
     /// - Returns: new account
     public func `import`(json: Data, password: String, newPassword: String, coin: SLIP.CoinType) throws -> Wallet {
         let key = try JSONDecoder().decode(KeystoreKey.self, from: json)
-        if let address = key.address, self.account(for: address, type: key.type) != nil {
-            throw Error.accountAlreadyExists
-        }
 
         var data = try key.decrypt(password: password)
         defer {
@@ -102,17 +99,6 @@ public final class KeyStore {
             let bc = blockchain(coin: coin)
             return try self.import(mnemonic: mnemonic, encryptPassword: newPassword, derivationPath: bc.derivationPath(at: 0))
         }
-    }
-
-    private func account(for address: Address, type: WalletType) -> Account? {
-        return wallets.compactMap({ wallet in
-            if wallet.type != type {
-                return nil
-            }
-            return wallet.accounts.first(where: { account in
-                account.address.data == address.data
-            })
-        }).first
     }
 
     /// Imports a private key.


### PR DESCRIPTION
I don't think we need to care if there is already wallet exist, every wallet could handle this functionality themselves. 

This fixes an issue for users not being able to import wallet in some cases